### PR TITLE
[Feature] 예약 로직에 이메일전송로직 추가

### DIFF
--- a/src/main/java/com/cloudboot/room_reservation/alarm/service/ReservationEmailSender.java
+++ b/src/main/java/com/cloudboot/room_reservation/alarm/service/ReservationEmailSender.java
@@ -8,6 +8,7 @@ import java.util.Map;
 
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.cloudboot.room_reservation.alarm.enumerate.ReservationMailStatus;
 import com.cloudboot.room_reservation.member.entity.Member;
@@ -55,6 +56,21 @@ public class ReservationEmailSender {
 				reservation);
 		
 	}	
+	
+	/**
+	 * 예약 알림 전송
+	 * - APPROVED (승인)
+	 * - REJECTED (거절)
+	 * - CANCELED (취소)
+	 * @param reservation
+	 */
+	@Transactional
+	public void send(Reservation reservation) {
+		// fetch join 하여 데이터 가져옴
+		reservationRepository.findByReservationId(reservation.getReservationId());
+		send(ReservationMailStatus.valueOf(reservation.getStatus().toString()), 
+				reservation);
+	}
 	
 	/**
 	 * 10분 전 예약 알림 전송

--- a/src/main/java/com/cloudboot/room_reservation/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/cloudboot/room_reservation/reservation/repository/ReservationRepository.java
@@ -30,4 +30,11 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     		+ "WHERE r.startTime BETWEEN :start and :end")
     List<Reservation> findByStartTimeBetween(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
     
+    
+    @Query("select r FROM Reservation r "
+    		+ "JOIN FETCH r.member "
+    		+ "JOIN FETCH r.room "
+    		+ "WHERE r.reservationId = :reservationId")
+    Reservation findByReservationId(@Param("reservationId") Long reservationId);
+    
 }

--- a/src/main/java/com/cloudboot/room_reservation/reservation/service/ReservationAdminService.java
+++ b/src/main/java/com/cloudboot/room_reservation/reservation/service/ReservationAdminService.java
@@ -1,11 +1,13 @@
 package com.cloudboot.room_reservation.reservation.service;
 
+import com.cloudboot.room_reservation.alarm.service.ReservationEmailSender;
 import com.cloudboot.room_reservation.reservation.dto.response.ReservationListResponseDto;
 import com.cloudboot.room_reservation.reservation.entity.Reservation;
 import com.cloudboot.room_reservation.reservation.enumerate.ReservationStatus;
 import com.cloudboot.room_reservation.reservation.repository.ReservationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -14,9 +16,14 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class ReservationAdminService {
-    private final ReservationRepository reservationRepository;
+    
+	private final ReservationRepository reservationRepository;
+	
+	private final ReservationEmailSender reservationEmailSender;
+    
 
     // 1. 관리자) 예약 승인
+	@Transactional
     public void approveReservation(Long reservationId) {
         Reservation reservation = reservationRepository.findById(reservationId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 예약이 존재하지 않습니다."));
@@ -29,11 +36,13 @@ public class ReservationAdminService {
         reservation.setStatus(ReservationStatus.APPROVED);
         reservation.setUpdatedAt(LocalDateTime.now());
         reservationRepository.save(reservation);
-        // 이후 메일 전송 기능 연결
-        // emailService.sendApprovalEmail(reservation);
+        
+        // 메일 전송
+        reservationEmailSender.send(reservation);
     }
 
     // 2. 관리자) 예약 거절
+	@Transactional
     public void rejectReservation(Long reservationId) {
         Reservation reservation = reservationRepository.findById(reservationId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 예약이 존재하지 않습니다."));
@@ -47,8 +56,9 @@ public class ReservationAdminService {
         reservation.setStatus(ReservationStatus.REJECTED);
         reservation.setUpdatedAt(LocalDateTime.now());
         reservationRepository.save(reservation);
-        // 이후 메일 전송 기능 연결
-        // emailService.sendRejectionEmail(reservation);
+        
+        // 메일 전송
+        reservationEmailSender.send(reservation);
     }
 
     // 3. 관리자) 전체 예약 목록 조회

--- a/src/main/java/com/cloudboot/room_reservation/reservation/service/ReservationService.java
+++ b/src/main/java/com/cloudboot/room_reservation/reservation/service/ReservationService.java
@@ -1,5 +1,6 @@
 package com.cloudboot.room_reservation.reservation.service;
 
+import com.cloudboot.room_reservation.alarm.service.ReservationEmailSender;
 import com.cloudboot.room_reservation.member.entity.Member;
 import com.cloudboot.room_reservation.member.repository.MemberRepository;
 import com.cloudboot.room_reservation.reservation.dto.request.ReservationRequestDto;
@@ -12,6 +13,7 @@ import com.cloudboot.room_reservation.room.repository.RoomRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -24,8 +26,12 @@ public class ReservationService {
     private final ReservationRepository reservationRepository;
     private final RoomRepository roomRepository;
     private final MemberRepository memberRepository;
+    
+    private final ReservationEmailSender reservationEmailSender;
+    
 
     // 1. 사용자) 예약 생성
+    @Transactional
     public void createReservation(ReservationRequestDto request) {
         Member member = memberRepository.findById(request.getMemberId())
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
@@ -53,6 +59,7 @@ public class ReservationService {
         reservationRepository.save(reservation);
     }
     // 2. 사용자) 예약 취소
+    @Transactional
     public void cancelReservation(Long reservationId){
         Reservation reservation = reservationRepository.findById(reservationId)
                 .orElseThrow(() -> new IllegalArgumentException("예약을 찾을 수 없습니다."));
@@ -63,6 +70,9 @@ public class ReservationService {
         reservation.setStatus(ReservationStatus.CANCELED);
         reservation.setUpdatedAt(LocalDateTime.now());
         reservationRepository.save(reservation);
+        
+        // 메일 전송
+        reservationEmailSender.send(reservation);
     }
     // 3. 사용자) 예약 목록 조회
     public List<ReservationListResponseDto> getUserReservations(Long memberId) {


### PR DESCRIPTION
## 개발 기능
예약 승인/거절/취소 로직에 이메일전송로직 추가

## 리뷰 요청
lazy 조건으로 Member, Room 을 조회하지 못하는 오류 발생하여
fetch join 으로 한번에 조회함

## API 테스트
  - 관리자 승인
    - /api/admin/reservations/{reservationId}/approve
  - 관리자 거절
    - /api/admin/reservations/{reservationId}/reject
  - 시용자 취소
    - /api/reservations/{reservationId}/cancel