### PR TITLE
[FEAT] 52.78.167.174 CORS 설정 추가

### DIFF
--- a/src/main/java/com/cloudboot/room_reservation/util/config/SecurityConfig.java
+++ b/src/main/java/com/cloudboot/room_reservation/util/config/SecurityConfig.java
@@ -90,7 +90,7 @@ public class SecurityConfig {
                                         "/html/dashboard/admin-profile.html"
                                 ).hasRole("ADMIN")
                                 .requestMatchers("/api/member/**", "/api/reservations/**", "/api/notice/**").hasRole("USER")
-                                .requestMatchers("/api/admin/**", "/admin").hasRole("ADMIN")
+                                .requestMatchers("/api/admin/**", "/admin", "/admin/**").hasRole("ADMIN")
                                 .requestMatchers("/api/member", "/html/dashboard/my-profile.html", "/html/dashboard/change-password.html").hasAnyRole("USER", "ADMIN")
 
                         .anyRequest().authenticated()
@@ -119,7 +119,7 @@ public class SecurityConfig {
                     public CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
                         CorsConfiguration configuration = new CorsConfiguration();
 
-                        configuration.setAllowedOrigins(Arrays.asList("http://127.0.0.1:5500", "http://127.0.0.1:8080", "http://localhost:8080"));
+                        configuration.setAllowedOrigins(Arrays.asList("http://52.78.167.174:8080", "http://127.0.0.1:8080", "http://localhost:8080"));
                         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
                         configuration.setAllowCredentials(true);
                         configuration.setAllowedHeaders(Collections.singletonList("*"));


### PR DESCRIPTION
[핵심 오류]
- @PutMapping에 대한 CORS 설정 오류 발생

[원인]
- PUT이나 PATCH는 Spring Security에서 Preflight 처리를 추가적으로 수행 
- Preflight : 실제 요청을 보내기 전, 사전에 서버에 OPTIONS 요청을 보내서 승인이 났을 때 실제 요청을 보내도록 하는 기능

[해결방법]
- POST/GET은 preflight을 수행하지 않음
- PUT/PATCH를 쓰지않고  POST/GET을 써서 해결 가능하지만 실질적인 처리 방식은 아님
-  setAllowedOrigins에서 http://52.78.167.174:8080을 명시적으로 작성하여 CORS 설정 허용

[추가해결]
- 만약 해결 안되면 아래 수행
- MemberAdminController의 editMemberRole의 메서드 매핑을 PUT이 아닌 POST로 변경
- manage-member.js의 메서드 요청을 PUT이 아닌 POST로 변경